### PR TITLE
fix #11 possible incorrect link location after buffer modified

### DIFF
--- a/README.org
+++ b/README.org
@@ -216,6 +216,7 @@ I'm considering adding some kind of index kind of thing in the spirit of zettelk
 
 Bugfixes
 - respect org-mode link configurations
+- fix possible incorrect link location after buffer modified by hook(s)
 
 ** 0.2
 

--- a/org-super-links.el
+++ b/org-super-links.el
@@ -179,22 +179,24 @@ Where the backlink is placed is determined by the variable `sl-backlink-into-dra
   "Insert link to BUFFER POS at current `point`, and create backlink to here.
 Only create backlinks in files in `org-mode', otherwise just act like a
 normal link."
-  (run-hooks 'sl-pre-link-hook)
-  (call-interactively 'org-store-link)
-  (let ((back-link (pop org-stored-links)))
-    (with-current-buffer buffer
-      (save-excursion
-	(goto-char pos)
-	(run-hooks 'sl-pre-backlink-hook)
-	(when (string-equal major-mode "org-mode")
-	  (sl-insert-backlink (car back-link) (cadr back-link)))
-	(call-interactively 'org-store-link))))
-  (let* ((forward-link (pop org-stored-links))
-	 (link (car forward-link))
-	 (description (sl-default-description-formatter link (cadr forward-link))))
-    (insert (sl-link-prefix))
-    (org-insert-link nil link description)
-    (insert (sl-link-postfix))))
+  (let ((b1 (make-marker)))
+    (set-marker b1 pos buffer)
+    (run-hooks 'sl-pre-link-hook)
+    (call-interactively 'org-store-link)
+    (let ((back-link (pop org-stored-links)))
+      (with-current-buffer (marker-buffer b1)
+	(save-excursion
+	  (goto-char (marker-position b1))
+	  (run-hooks 'sl-pre-backlink-hook)
+	  (when (string-equal major-mode "org-mode")
+	    (sl-insert-backlink (car back-link) (cadr back-link)))
+	  (call-interactively 'org-store-link))))
+    (let* ((forward-link (pop org-stored-links))
+	   (link (car forward-link))
+	   (description (sl-default-description-formatter link (cadr forward-link))))
+      (insert (sl-link-prefix))
+      (org-insert-link nil link description)
+      (insert (sl-link-postfix)))))
 
 ;;;###autoload
 (defun sl-store-link (&optional GOTO KEYS)


### PR DESCRIPTION
if the buffer is modified by a hook the link location could be
incorrect.

use markers for tracking position to prevent this

see #11 