### PR TITLE
Don't require helm by default; use org-refile's machinery

### DIFF
--- a/README.org
+++ b/README.org
@@ -173,7 +173,12 @@ The variables below allow quite a bit of flexibility to allow you to fit =org-su
 
    See the functions =sl-get-location= (in the =org-super-links.el= file) or =sl-link-search-interface-ql= (in =org-super-links-org-ql.el=) for examples.
 
-   Default is =sl-get-location=, which internally uses =org-refile-get-location=.
+   Default is set based on currently installed packages. In order of priortity:
+   1. "helm-org-ql"
+   2. "helm-org-rifle"
+   3. =sl-get-location=
+
+   =sl-get-location= internally uses =org-refile-get-location=.
 
 * Tips
 
@@ -299,6 +304,8 @@ I'm considering adding some kind of index kind of thing in the spirit of zettelk
 
 * Changelog
 
+- remove dependency on helm
+  - add sl-get-location search function [[https://github.com/piater][@piater]]
 - add related into drawer option
 - add quick inserts
   - sl-quick-insert-drawer-link

--- a/README.org
+++ b/README.org
@@ -35,8 +35,6 @@ This has a link pointing to the heading above
 
 This needs better instructions, but here's something basic at least for now. Once I'm reasonably happy with the interface etc. I'll try to get this on melpa.
 
-There is a dependency on either [[https://github.com/alphapapa/org-ql][helm-org-ql]] or [[https://github.com/alphapapa/org-rifle][helm-org-rifle]], so you will need at least one of those installed, or you can define a custom search function. By default it will use =helm-org-ql=. See '[[id:ba63c582-56ba-4772-94f6-8319f1b33ff0][sl-default-description-formatter]]' for details.
-
 This isn't on melpa, but using [[https://github.com/quelpa/quelpa][quelpa]] makes it easy. Example basic configuration:
 #+begin_src elisp
   (use-package org-super-links
@@ -164,19 +162,18 @@ The variables below allow quite a bit of flexibility to allow you to fit =org-su
 
    The interface to use for finding target links.
    This can be a string with one of the values 'helm-org-ql',
-   'helm-org-rifle', or a custom function.  If you provide a custom
+   'helm-org-rifle', or a function.  If you provide a custom
    function it will be called with the `point` at the location the link
    should be inserted.  The only other requirement is that it should call
    the function =sl--insert-link= with the `buffer` and `pos` of the
    target link.  AKA the place you want the backlink.
 
-   Using 'helm-org-ql' or 'helm-org-rifle' will also add a new action to
+   Using [[https://github.com/alphapapa/org-ql][helm-org-ql]] or [[https://github.com/alphapapa/org-rifle][helm-org-rifle]] will also add a new action to
    the respective action menu.
 
-   See the function =sl-link-search-interface-ql= in the
-   =org-super-links-org-ql.el= file for an example.
+   See the functions =sl-get-location= (in the =org-super-links.el= file) or =sl-link-search-interface-ql= (in =org-super-links-org-ql.el=) for examples.
 
-   Default "=helm-org-ql="
+   Default is =sl-get-location=, which internally uses =org-refile-get-location=.
 
 * Tips
 

--- a/org-super-links.el
+++ b/org-super-links.el
@@ -84,10 +84,10 @@ function will be called for every link.
 
 Default is the variable `org-make-link-desciption-function'.")
 
-(defvar sl-search-function "helm-org-ql"
+(defvar sl-search-function 'sl-get-location
   "The interface to use for finding target links.
 This can be a string with one of the values 'helm-org-ql',
-'helm-org-rifle', or a custom function.  If you provide a custom
+'helm-org-rifle', or a function.  If you provide a custom
 function it will be called with the `point` at the location the link
 should be inserted.  The only other requirement is that it should call
 the function `sl--insert-link' with a marker to the target link.  AKA
@@ -108,6 +108,12 @@ This is called with point in the heading of the backlink.")
 
 (declare-function sl-link-search-interface-ql "ext:org-super-links-org-ql")
 (declare-function sl-link-search-interface-rifle "ext:org-super-links-org-rifle")
+
+(defun sl-get-location ()
+  "An `sl-search-function' that reuses the org-refile machinery."
+  (let ((target (org-refile-get-location "Super Link")))
+    (sl--insert-link (set-marker (make-marker) (car (cdddr target))
+				 (get-file-buffer (car (cdr target)))))))
 
 (defun sl-search-function ()
   "Call the search interface specified in `sl-search-function'."

--- a/org-super-links.el
+++ b/org-super-links.el
@@ -84,7 +84,10 @@ function will be called for every link.
 
 Default is the variable `org-make-link-desciption-function'.")
 
-(defvar sl-search-function 'sl-get-location
+(defvar sl-search-function
+  (cond ((require 'helm-org-ql nil 'no-error) "helm-org-ql")
+	((require 'helm-org-rifle nil 'no-error) "helm-org-rifle")
+	(t 'sl-get-location))
   "The interface to use for finding target links.
 This can be a string with one of the values 'helm-org-ql',
 'helm-org-rifle', or a function.  If you provide a custom
@@ -96,7 +99,14 @@ the place you want the backlink.
 Using 'helm-org-ql' or 'helm-org-rifle' will also add a new action to
 the respective action menu.
 
-See the function `sl-link-search-interface-ql' or for an example.")
+See the function `sl-link-search-interface-ql' or for an example.
+
+Default is set based on currently installed packages.  In order of priortity:
+- 'helm-org-ql'
+- 'helm-org-rifle'
+- `sl-get-location'
+
+`sl-get-location' internally uses `org-refile-get-location'.")
 
 (defvar sl-pre-link-hook nil
   "Hook called before storing the link on the link side.


### PR DESCRIPTION
Helm is great but there are many Emacs users who don't use it and would like to use org-super-links. This pull request removes the hard dependence on helm by providing a wrapper around `org-refile-get-location` as a default for `sl-search-function`.

The commits in this PR should be squashed when merging.