### PR TITLE
delete backlinks #36

### DIFF
--- a/README.org
+++ b/README.org
@@ -76,7 +76,7 @@ The inverse of =sl-quick-insert-inline-link=. Insert a link ignoring the =sl-rel
 
 *** sl-delete-link
 
-Delete the link under cursor, and the corresponding reverse link.
+Delete the link at point, and the corresponding reverse link.
 If no reverse link exists, just delete link at point.
 This works from either side, and deletes both sides of a link.
 

--- a/README.org
+++ b/README.org
@@ -279,10 +279,10 @@ This combination of tags and index headings makes it easy to find things.
 (use-package org-super-links
   :quelpa (org-super-links :repo "toshism/org-super-links" :fetcher github :commit "develop")
   :bind (("C-c s s" . sl-link)
-	 ("C-c s l" . sl-store-link)
-	 ("C-c s C-l" . sl-insert-link)
-	 ("C-c s d" . sl-quick-insert-drawer-link)
-	 ("C-c s i" . sl-quick-insert-inline-link)
+         ("C-c s l" . sl-store-link)
+         ("C-c s C-l" . sl-insert-link)
+         ("C-c s d" . sl-quick-insert-drawer-link)
+         ("C-c s i" . sl-quick-insert-inline-link)
          ("C-c s C-d" . sl-delete-link))
   :config
   (setq sl-related-into-drawer t

--- a/README.org
+++ b/README.org
@@ -74,6 +74,12 @@ Creates a link ignoring the =sl-related-into-drawer= and =sl-link-prefix= settin
 
 The inverse of =sl-quick-insert-inline-link=. Insert a link ignoring the =sl-related-into-drawer= and =sl-link-prefix= settings. Inserts a link using =sl-link-prefix-timestamp= for the prefix and either =sl-related-into-drawer= or =sl-related-drawer-default-name= for the drawer name. =sl-related-into-drawer= has precedence if it's set to a string.
 
+*** sl-delete-link
+
+Delete the link under cursor, and the corresponding reverse link.
+If no reverse link exists, just delete link at point.
+This works from either side, and deletes both sides of a link.
+
 * Configuration
 
 The variables below allow quite a bit of flexibility to allow you to fit =org-super-links= into your workflow. None of these are required. My personal config is below under Tips
@@ -276,7 +282,8 @@ This combination of tags and index headings makes it easy to find things.
 	 ("C-c s l" . sl-store-link)
 	 ("C-c s C-l" . sl-insert-link)
 	 ("C-c s d" . sl-quick-insert-drawer-link)
-	 ("C-c s i" . sl-quick-insert-inline-link))
+	 ("C-c s i" . sl-quick-insert-inline-link)
+         ("C-c s C-d" . sl-delete-link))
   :config
   (setq sl-related-into-drawer t
   	sl-link-prefix 'sl-link-prefix-timestamp))
@@ -304,6 +311,7 @@ I'm considering adding some kind of index kind of thing in the spirit of zettelk
 
 * Changelog
 
+- add delete link
 - fixed bug with org-capture prefix being swallowed (thanks! [[https://github.com/piater][@piater]])
 - remove dependency on helm
   - add sl-get-location search function [[https://github.com/piater][@piater]]

--- a/org-super-links.el
+++ b/org-super-links.el
@@ -233,20 +233,6 @@ If point is in drawer, delete the entire line."
 	  (org-remove-empty-drawer-at (point)))
       (delete-region (org-element-property :begin link) (org-element-property :end link)))))
 
-(defun sl-delete-link ()
-  "Delete the link under cursor, and the corresponding reverse link.
-If no reverse link exists, just delete link at point."
-  (interactive)
-  (save-window-excursion
-    (with-current-buffer (current-buffer)
-      (save-excursion
-	(let ((id (org-id-get (point))))
-	  (org-open-at-point)
-	  (let ((link-element (sl--find-link id)))
-	    (if link-element
-		(sl--delete-link link-element)
-	      (message "No backlink found. Deleting active only.")))))))
-  (sl--delete-link (org-element-context)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; EXPERIMENTAL related into drawer
@@ -336,6 +322,23 @@ act like a normal link."
 	 (link (car forward-link))
 	 (description (sl-default-description-formatter link (cadr forward-link))))
     (sl-insert-relatedlink link description)))
+
+;;;###autoload
+(defun sl-delete-link ()
+  "Delete the link under cursor, and the corresponding reverse link.
+If no reverse link exists, just delete link at point.
+This works from either side, and deletes both sides of a link."
+  (interactive)
+  (save-window-excursion
+    (with-current-buffer (current-buffer)
+      (save-excursion
+	(let ((id (org-id-get (point))))
+	  (org-open-at-point)
+	  (let ((link-element (sl--find-link id)))
+	    (if link-element
+		(sl--delete-link link-element)
+	      (message "No backlink found. Deleting active only.")))))))
+  (sl--delete-link (org-element-context)))
 
 ;;;###autoload
 (defun sl-store-link (&optional GOTO KEYS)

--- a/org-super-links.el
+++ b/org-super-links.el
@@ -325,7 +325,7 @@ act like a normal link."
 
 ;;;###autoload
 (defun sl-delete-link ()
-  "Delete the link under cursor, and the corresponding reverse link.
+  "Delete the link at point, and the corresponding reverse link.
 If no reverse link exists, just delete link at point.
 This works from either side, and deletes both sides of a link."
   (interactive)


### PR DESCRIPTION
Add support for deleting links. Deletes link at point, and also the link on the target side of link. 

If point is on link both link and backlink will be deleted. This works from either side. So deleting a backlink will also delete the link.