### PR TITLE
convert boring regular link to super link! #13

### DIFF
--- a/README.org
+++ b/README.org
@@ -341,6 +341,7 @@ This is still kind of in flux, so things could change... It's starting to settle
 
 * Changelog
 
+- add sl-convert-link-to-super
 - add delete link
 - fixed bug with org-capture prefix being swallowed (thanks! [[https://github.com/piater][@piater]])
 - remove dependency on helm

--- a/README.org
+++ b/README.org
@@ -95,6 +95,15 @@ Delete the link at point, and the corresponding reverse link.
 If no reverse link exists, just delete link at point.
 This works from either side, and deletes both sides of a link.
 
+*** sl-convert-link-to-super
+
+Convert a normal org-mode link at `point' to super link.  If
+=sl-related-into-drawer= is non-nil move the link into drawer.
+
+When called interactively with a =C-u= prefix argument ignore
+=sl-related-into-drawer= configuration and do not modify existing
+link. Only add the backlink.
+
 * Configuration
 
 The variables below allow quite a bit of flexibility to allow you to fit =org-super-links= into your workflow. None of these are required. My personal config is [[#my-personal-setup-and-configuration][here]]


### PR DESCRIPTION
add function that will convert org link under point to super link

by default respects `sl-related-into-drawer` config
with prefix arg ignores config and does not modify existing link, only adds the backlink