### PR TITLE
fix incorrect backlink #46

### DIFF
--- a/README.org
+++ b/README.org
@@ -341,6 +341,9 @@ This is still kind of in flux, so things could change... It's starting to settle
 
 * Changelog
 
+Bugfixes
+- fixed incorrect link when backlink-into-drawer nil
+
 ** 0.3
 
 [2020-09-21]

--- a/org-super-links.el
+++ b/org-super-links.el
@@ -298,7 +298,8 @@ Where the backlink is placed is determined by the variable `sl-backlink-into-dra
   (let* ((org-log-into-drawer (sl-backlink-into-drawer))
 	 (description (sl-default-description-formatter link desc))
 	 (beg (org-log-beginning t)))
-    (goto-char beg)
+    (when org-log-into-drawer
+      (goto-char beg))
     (insert (sl-backlink-prefix))
     (org-insert-link nil link description)
     (insert (sl-backlink-postfix))


### PR DESCRIPTION
When linking to an empty heading and backlink-into-drawer is nil the
backlink is incorrectly set.

see #46 