### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/org-super-links.el
+++ b/org-super-links.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (require 'org)
+(require 'org-element)
 
 (defvar org-super-links-backlink-into-drawer t
   "Controls how/where to insert the backlinks.


### PR DESCRIPTION
```
org-super-links.el:432:1:Warning: the following functions are not known to be defined:
    org-element-map, org-element-parse-buffer, org-element-property,
    org-element-type
```