### PR TITLE
Add capture target buffer to search targets

### DIFF
--- a/org-super-links-org-ql.el
+++ b/org-super-links-org-ql.el
@@ -43,12 +43,13 @@ If BUFFER-OR-NAME is nil return current buffer's mode."
 (defun org-super-links-org-ql-get-search-buffers ()
   "Return the buffers to provide to `helm-org-ql`.
 If the current buffer is an `org-mode` buffer add it to `org-agenda-files`.
+If the current buffer is a capture buffer add the target buffer to `org-agenda-files`
 Else just return `org-agenda-files`"
-  ;; this needs to add the buffer you were on before opening a capture
-  ;; template too (if it's an org mode file)
-  (if (and (string= (org-super-links-org-ql-buffer-mode) "org-mode") (buffer-file-name))
-      (cons (buffer-file-name) (org-agenda-files))
-    (org-agenda-files)))
+  (let ((current-or-target-buffer (or (buffer-file-name) (buffer-file-name (org-capture-get :buffer)))))
+    (if (and (string= (org-super-links-org-ql-buffer-mode) "org-mode")
+	     current-or-target-buffer)
+	(cons current-or-target-buffer (org-agenda-files))
+      (org-agenda-files))))
 
 
 (defun org-super-links-org-ql-link-search-interface ()


### PR DESCRIPTION
This one is pretty edge case but it happened to me and it was
annoying.

If calling org-super-links-link from a capture buffer that has a
target which is not included in org-agenda-files; add the target buffer
to the agenda files so that it shows in search candidates.

Without this you can't link to the buffer you called the capture from
unless it's in your agenda files.

This still isn't perfect but close enough, it works.