### PR TITLE
Use org-time-stamp-format function to obtain the timestamp format

### DIFF
--- a/org-super-links.el
+++ b/org-super-links.el
@@ -166,10 +166,8 @@ This is called with point in the heading of the backlink.")
   "Return the default prefix string for a backlink.
 Inactive timestamp formatted according to `org-time-stamp-formats' and
 a separator ' <- '."
-  (let* ((time-format (substring (cdr org-time-stamp-formats) 1 -1))
-	 (time-stamp (format-time-string time-format (current-time))))
-    (format "[%s] <- "
-	    time-stamp)))
+  (concat (format-time-string (org-time-stamp-format t t) (current-time))
+	" <- "))
 
 (defun org-super-links-default-description-formatter (link desc)
   "Return a string to use as the link desciption.
@@ -275,10 +273,8 @@ used instead of the default value."
   "Return the default prefix string for a backlink.
 Inactive timestamp formatted according to `org-time-stamp-formats' and
 a separator ' -> '."
-  (let* ((time-format (substring (cdr org-time-stamp-formats) 1 -1))
-	 (time-stamp (format-time-string time-format (current-time))))
-    (format "[%s] -> "
-	    time-stamp)))
+  (concat (format-time-string (org-time-stamp-format t t) (current-time))
+	" -> "))
 
 (defun org-super-links-quick-insert-drawer-link ()
   "Insert link into drawer regardless of variable `org-super-links-related-into-drawer' value."


### PR DESCRIPTION
The value of `org-time-stamp-formats` constant is going to be changed in Emacs 29:  https://git.sr.ht/~bzg/org-mode/commit/e3a7c01874c9bb80e04ffa58c578619faf09e7f0

This can break the format of the backlink prefix as in the example below:

> :BACKLINKS:
[Y-11-18 Fri 19:%] <- [[id:3bdc7eb2-afc4-4931-a6b1-b60953dc5813][Update on the change of org-time-stamp-formats]]
:END:

Rather than using the value of the variable directly, I would recommend you use `org-time-stamp-format' function to obtain the format. It now correctly renders as follows:

> :BACKLINKS:
[2022-11-18 Fri 19:25] <- [[id:3bdc7eb2-afc4-4931-a6b1-b60953dc5813][Update on the change of org-time-stamp-formats]]
:END: